### PR TITLE
fix wayland cursor size

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -19,6 +19,8 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.freedesktop.Flatpak"
+  # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810
+  - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:
   # Podman Desktop sources
   - name: podman-desktop


### PR DESCRIPTION
On HiDPI screens the cursor will be very tiny.
This is a known for electron and can be fixed by setting an environment variable. 

See: https://github.com/electron/electron/issues/19810

The same solution is already applied for other flatpaks e.g. vs-code.