### PR TITLE
revert back to x11 from wayland

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -9,8 +9,7 @@ sdk-extensions:
 command: run.sh
 separate-locales: false
 finish-args:
-  - "--socket=fallback-x11"
-  - "--socket=wayland"
+  - "--socket=x11"
   - "--share=ipc"
   - "--device=dri"
   - "--filesystem=home"
@@ -20,7 +19,7 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.freedesktop.Flatpak"
-  # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810
+  # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:
   # Podman Desktop sources


### PR DESCRIPTION
revert back to x11 from wayland

We are getting reports of linux users unable to use podman desktop now,
so we are reverting back to x11 which has been consistent in not having
startup failures.

As per flatpak docs we shouldn't use wayland just yet: "Native wayland
support in electron is experimental and often unstable. It is advised to
stick with the X11 and Xwayland configuration above as the default."
(https://docs.flatpak.org/en/latest/electron.html)

Reverting back to x11.

Closes https://github.com/flathub/io.podman_desktop.PodmanDesktop/issues/51

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
