### PR TITLE
fix: add access to auth.json file

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -14,6 +14,7 @@ finish-args:
   - "--device=dri"
   - "--filesystem=home"
   - "--filesystem=xdg-run/podman:create"
+  - "--filesystem=xdg-run/containers/auth.json"
   - "--filesystem=/run/docker.sock"
   - "--share=network"
   - "--talk-name=org.freedesktop.Notifications"


### PR DESCRIPTION
Podman Desktop is reading/writing to this file but if the user is adding registries within the UI, then the registries are only visible from the UI, not from the CLI as it is not granting the access to the user's filesystem folder

adding permission to be able to read/write to this file


related to https://github.com/containers/podman-desktop/issues/1632