### PR TITLE
feat: bump runtimes to 24.08

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -1,9 +1,9 @@
 app-id: io.podman_desktop.PodmanDesktop
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20
 command: run.sh


### PR DESCRIPTION
built with:

`flatpak run org.flatpak.Builder --install --install-deps-from=flathub --force-clean build io.podman_desktop.PodmanDesktop.yml`

quick testing of mine shows that it works just fine