### PR TITLE
fix: allow use safeStorage in electron running from flatpak

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -10,6 +10,7 @@ command: run.sh
 separate-locales: false
 finish-args:
   - "--socket=x11"
+  - "--socket=wayland"
   - "--share=ipc"
   - "--device=dri"
   - "--filesystem=home"
@@ -20,6 +21,7 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.freedesktop.Flatpak"
+  - "--own-name=org.freedesktop.secrets"
   # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:

--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -20,7 +20,8 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.freedesktop.Flatpak"
-  - "--socket=session-bus"
+  - "--talk-name=org.freedesktop.secrets"
+  - "--talk-name=org.kde.kwalletd6"
   # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:

--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -20,7 +20,7 @@ finish-args:
   - "--talk-name=org.freedesktop.Notifications"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.freedesktop.Flatpak"
-  - "--own-name=org.freedesktop.secrets"
+  - "--socket=session-bus"
   # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
 modules:

--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -10,7 +10,6 @@ command: run.sh
 separate-locales: false
 finish-args:
   - "--socket=x11"
-  - "--socket=wayland"
   - "--share=ipc"
   - "--device=dri"
   - "--filesystem=home"


### PR DESCRIPTION
Fix adds new parameter to the build to allow safeSorage to use encryption on Gnome desktop environment.
Fix https://github.com/podman-desktop/podman-desktop/issues/10858.
