### PR TITLE
fix: grant access to the containers directory for the flatpak build

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -14,7 +14,7 @@ finish-args:
   - "--device=dri"
   - "--filesystem=home"
   - "--filesystem=xdg-run/podman:create"
-  - "--filesystem=xdg-run/containers/auth.json"
+  - "--filesystem=xdg-run/containers:create"
   - "--filesystem=/run/docker.sock"
   - "--share=network"
   - "--talk-name=org.freedesktop.Notifications"


### PR DESCRIPTION
Back port of https://github.com/podman-desktop/podman-desktop/pull/11654

> The following changes request fixes the problem, when user using flatpak build can not save the application preferences (proxy settings).
> 
> The main problem was occurred due to sandbox policy in flatpak ecosystem. Application wasn't able to see the directory `/run/user/1000/containers` and couldn't update the `/run/user/1000/containers/containers.conf` file. `xdg-run` is an alias for `/run/user/1000`, so adding an additional finishArg solved the problem. The new arg was added to flatpak configuration:
> 
> ```
> '--filesystem=xdg-run/containers:create',
> ```