### PR TITLE
fix: test build to check if it solves safestorage decryption

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -26,6 +26,31 @@ finish-args:
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
   - "--env=XDG_SESSION_TYPE=x11"
 modules:
+  # fix libsecret under flatpak
+  # https://github.com/flathub/org.signal.Signal/pull/756/commits/2caf105b18f906e7707f67b3cf7384a21f461564
+  # https://github.com/flathub/com.vscodium.codium/issues/239#issuecomment-1833799015
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dmanpage=false
+      - -Dcrypto=disabled
+      - -Dvapi=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+      - -Dbash_completion=disabled
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz
+        sha256: 6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e
+        x-checker-data:
+          type: gnome
+          name: libsecret
+          stable-only: true
   # Podman Desktop sources
   - name: podman-desktop
     buildsystem: simple


### PR DESCRIPTION
On gnome electron based app installed with flatpak keeps using wrong key, to decrypt safeStorage after restart.
This is attempt to fix it the same way as vscodium did a while ago.

Fixes https://github.com/podman-desktop/podman-desktop/issues/13296.

To replicate the issue:
1. Install 1.22 from flathub
2. Login to RH SSO
3. Make sure UI is updated and you account shows up on Authentication settings page
4. Exit from Podman Desktop and start it again
5. Authentication settings page should be empty and there would be exception reported in Devtools Console