### PR TITLE
fix: remove XDG_SESSION_TYPE environment variable

### DIFF
--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -9,7 +9,8 @@ sdk-extensions:
 command: run.sh
 separate-locales: false
 finish-args:
-  - "--socket=x11"
+  - "--socket=fallback-x11"
+  - "--socket=wayland"
   - "--share=ipc"
   - "--device=dri"
   - "--filesystem=home"

--- a/io.podman_desktop.PodmanDesktop.yml
+++ b/io.podman_desktop.PodmanDesktop.yml
@@ -30,7 +30,6 @@ finish-args:
   - "--talk-name=org.kde.kwalletd6"
   # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
   - "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons"
-  - "--env=XDG_SESSION_TYPE=x11"
 modules:
   # Podman Desktop sources
   - name: podman-desktop


### PR DESCRIPTION
This workaround is not required with latest electron release.

Fix https://github.com/podman-desktop/podman-desktop/issues/14388.